### PR TITLE
Express middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,16 @@ Simply pass in your connect-based server as an option at setup.
 var express = require("express");
 var Service = require("rest-methods/server");
 
-var app = express();
 var service = Service({
   name:'My Service',
   version: '1.0.1',
   basePath: '/v1',
-  connect: app
 });
+
+var app = express()
+          .use(service.middleware)
+          .listen(3030);
+
 ```
 
 The example above shows additional configuration options, including your service's `version` and a base path that all REST urls are prefixed with.

--- a/example/remote.js
+++ b/example/remote.js
@@ -11,7 +11,7 @@ server.onReady(function(){
 
   console.log('Invoking: server.methods.bar.get(123, 5)');
   console.log("");
-  server.methods.bar.get(123, 5)
+  server.methods.bar.put(123, 5, { date: new Date() })
     .then(function(result) {
       console.log('Callback Result', result);
       console.log('');

--- a/example/service.js
+++ b/example/service.js
@@ -1,13 +1,20 @@
-import Server from '../server';
+import Service from '../server';
 import * as util from "js-util";
 
-var service = Server({
+import express from "express";
+
+
+var service = Service({
   name:'My Service',
   version: '1.0.1',
   basePath: '/v1'
   // docs: true
-}).start({ port:3030, silent:false });
+})//.start({ port:3030, silent:false });
 
+
+const app = express()
+  .use(service.middleware)
+  .listen(3030);
 
 
 service.methods({
@@ -65,7 +72,12 @@ service.methods({
       // this.throw(403, "Thing");
       // return {id:id, date:new Date(), skip:skip }
     },
-    put: (id, skip, count) => {}
+    put: (id, skip, data) => {
+
+      console.log("PUT", data);
+      return true
+
+    }
   },
 
 
@@ -94,8 +106,8 @@ service.methods({
 });
 
 
-service.before((e) => { console.log("BEFORE", e); });
-service.after((e) => { console.log("AFTER", e); });
+// service.before((e) => { console.log("BEFORE", e); });
+// service.after((e) => { console.log("AFTER", e); });
 
 
 // Invoke directly from the server.

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "mocha": "^2.2.1",
     "node-libs-browser": "^0.5.2",
     "sinon": "^1.15.4",
-    "webpack": "^1.10.1"
+    "webpack": "^1.10.1",
+    "express": "^4.13.3"
   },
   "scripts": {
     "test": "./node_modules/mocha/bin/mocha --recursive --compilers js:babel/register",

--- a/src/server/middleware.js
+++ b/src/server/middleware.js
@@ -1,13 +1,140 @@
 import fs from "fs";
 import fsPath from "path";
 import urlUtil from "url";
+import bodyParser from "body-parser";
 import getManifest from "./manifest";
 import docs from "../docs";
 import { MANIFEST_PATH, INVOKE } from "../const";
 import stylus from "stylus";
 import nib from "nib";
 
+const jsonParser = bodyParser.json();
 const FAVICON = fs.readFileSync(fsPath.join(__dirname, "../docs/favicon.ico"));
+
+
+// Middleware.
+const middleware = (server, req, res, next) => {
+  let basePath = server.basePath.replace(/\/$/, "");
+  let url = urlUtil.parse(req.url, true);
+
+  const cache = {};
+
+  const send = (content, contentType) => {
+      res.setHeader("Content-Type", contentType);
+      res.end(content);
+  };
+
+  const getFile = (fileName) => {
+      const path = fsPath.join(__dirname, fileName);
+      if (!cache[path]) {
+        // NB: Only load from file if not in the cache.
+        let text = fs.readFileSync(path).toString();
+        cache[path] = { text: text, path: path };
+      }
+      return cache[path];
+  };
+
+  const sendJs = (fileName) => {
+      let js = getFile(`../../.build/${ fileName }`).text;
+      send(js, "application/javascript");
+  };
+
+  const sendJson = (obj) => { send(JSON.stringify(obj), "application/json"); };
+  const sendHtml = (html) => { send(html, "text/html"); };
+  const sendCss = (css) => { send(css, "text/css"); };
+
+  const send404 = (message) => {
+    res.statusCode = 404;
+    send(message || "Not found", "text/plain");
+  };
+
+  const sendStylus = (fileName) => {
+      let file = getFile(fileName);
+      stylus(file.text)
+        .set("filename", file.path)
+        .include(nib.path)
+        .render((err, css) => {
+            if (err) { throw err; }
+            sendCss(css);
+        });
+  };
+
+  const sendDocsHtml = () => {
+      if (server.docs === true) {
+        let manifest = getManifest(server, { docs: true });
+        const pageProps = {
+          title: `${ server.name } (API)`,
+          manifest: manifest,
+          faviconPath: `${ basePath }/favicon.ico`,
+          stylePath: `${ basePath }/style.css`,
+          scriptPath: `${ basePath }/docs.js`,
+          bodyHtml: docs.toHtml(docs.Shell, { manifest: manifest })
+        };
+        sendHtml(docs.pageHtml(pageProps));
+
+      } else {
+        send404();
+      }
+  };
+
+  // Match the route.
+  switch (url.pathname) {
+    // GET: An HTML representation of the API (docs).
+    case basePath:
+        sendDocsHtml();
+        break;
+
+    case `${ basePath }/`:
+        sendDocsHtml();
+        break;
+
+    case `${ basePath }/style.css`:
+        sendStylus("../docs/css/index.styl");
+        break;
+
+    case `${ basePath }/favicon.ico`:
+        send(FAVICON, "image/x-icon");
+        break;
+
+    // GET: The manifest of methods.
+    case MANIFEST_PATH:
+        const withDocs = url.query.docs === "true";
+        sendJson(getManifest(server, { docs: withDocs }));
+        break;
+
+    // GET: Serve the client JS.
+    case `${ basePath }/browser.js`:
+        sendJs("browser.js");
+        break;
+
+    case `${ basePath }/docs.js`:
+        if (server.docs === true) {
+          sendJs("docs.js");
+        } else {
+          send404();
+        }
+        break;
+
+
+    default:
+        // Attempt to match the URL for a method.
+        const methodVerb = server.match(req.url, req.method);
+        if (methodVerb) {
+          // Invoke the method.
+          server[INVOKE](methodVerb, req.body.args, req.url)
+            .then((result) => { sendJson(result); })
+            .catch((err) => {
+                res.statusCode = err.status || 500;
+                sendJson(err);
+            });
+
+        } else {
+          // No match - continue to [next] middleware method.
+          next();
+        }
+  }
+};
+
 
 
 
@@ -17,126 +144,8 @@ const FAVICON = fs.readFileSync(fsPath.join(__dirname, "../docs/favicon.ico"));
 * @return the connect middleware function.
 */
 export default (server) => {
-  // Middleware.
-  return (req, res, next) => {
-      let basePath = server.basePath.replace(/\/$/, "");
-      let url = urlUtil.parse(req.url, true);
-
-      const cache = {};
-
-      const send = (content, contentType) => {
-          res.setHeader("Content-Type", contentType);
-          res.end(content);
-      };
-
-      const getFile = (fileName) => {
-          const path = fsPath.join(__dirname, fileName);
-          if (!cache[path]) {
-            // NB: Only load from file if not in the cache.
-            let text = fs.readFileSync(path).toString();
-            cache[path] = { text: text, path: path };
-          }
-          return cache[path];
-      };
-
-      const sendJs = (fileName) => {
-          let js = getFile(`../../.build/${ fileName }`).text;
-          send(js, "application/javascript");
-      };
-
-      const sendJson = (obj) => { send(JSON.stringify(obj), "application/json"); };
-      const sendHtml = (html) => { send(html, "text/html"); };
-      const sendCss = (css) => { send(css, "text/css"); };
-
-      const send404 = (message) => {
-        res.statusCode = 404;
-        send(message || "Not found", "text/plain");
-      };
-
-      const sendStylus = (fileName) => {
-          let file = getFile(fileName);
-          stylus(file.text)
-            .set("filename", file.path)
-            .include(nib.path)
-            .render((err, css) => {
-                if (err) { throw err; }
-                sendCss(css);
-            });
-      };
-
-      const sendDocsHtml = () => {
-          if (server.docs === true) {
-            let manifest = getManifest(server, { docs: true });
-            const pageProps = {
-              title: `${ server.name } (API)`,
-              manifest: manifest,
-              faviconPath: `${ basePath }/favicon.ico`,
-              stylePath: `${ basePath }/style.css`,
-              scriptPath: `${ basePath }/docs.js`,
-              bodyHtml: docs.toHtml(docs.Shell, { manifest: manifest })
-            };
-            sendHtml(docs.pageHtml(pageProps));
-
-          } else {
-            send404();
-          }
-      };
-
-      // Match the route.
-      switch (url.pathname) {
-        // GET: An HTML representation of the API (docs).
-        case basePath:
-            sendDocsHtml();
-            break;
-
-        case `${ basePath }/`:
-            sendDocsHtml();
-            break;
-
-        case `${ basePath }/style.css`:
-            sendStylus("../docs/css/index.styl");
-            break;
-
-        case `${ basePath }/favicon.ico`:
-            send(FAVICON, "image/x-icon");
-            break;
-
-        // GET: The manifest of methods.
-        case MANIFEST_PATH:
-            const withDocs = url.query.docs === "true";
-            sendJson(getManifest(server, { docs: withDocs }));
-            break;
-
-        // GET: Serve the client JS.
-        case `${ basePath }/browser.js`:
-            sendJs("browser.js");
-            break;
-
-        case `${ basePath }/docs.js`:
-            if (server.docs === true) {
-              sendJs("docs.js");
-            } else {
-              send404();
-            }
-            break;
-
-
-        default:
-            // Attempt to match the URL for a method.
-            const methodVerb = server.match(req.url, req.method);
-            if (methodVerb) {
-              // Invoke the method.
-              server[INVOKE](methodVerb, req.body.args, req.url)
-                .then((result) => { sendJson(result); })
-                .catch((err) => {
-                    res.statusCode = err.status || 500;
-                    sendJson(err);
-                });
-
-            } else {
-              // No match - continue to [next] middleware method.
-              next();
-            }
-      }
-    };
+  return function(req, res, next) {
+    // Return the middleware passed through the JSON parser.
+    jsonParser(req, res, () => { middleware(server, req, res, next); });
+  };
 };

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -2,7 +2,7 @@ import _ from "lodash";
 import Promise from "bluebird";
 import ServerMethod from "./ServerMethod";
 import middleware from "./middleware";
-import connectModule from "connect";
+import connect from "connect";
 import pageJS from "../page-js";
 import { METHODS, HANDLERS, INVOKE } from "../const";
 import { ServerMethodError } from "../errors";
@@ -258,7 +258,8 @@ class Server {
     const SILENT = options.silent || false;
 
     // Start the server.
-    http.createServer(this.connect).listen(PORT);
+    const app = connect().use(this.middleware);
+    http.createServer(app).listen(PORT);
 
     // Output some helpful details to the console.
     if (SILENT !== true) {

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -1,5 +1,4 @@
 import _ from "lodash";
-import bodyParser from "body-parser";
 import Promise from "bluebird";
 import ServerMethod from "./ServerMethod";
 import middleware from "./middleware";
@@ -54,7 +53,6 @@ class Server {
     this.version = options.version || "0.0.0";
     this.docs = _.isBoolean(options.docs) ? options.docs : true;
 
-
     // Private state.
     this[METHODS] = {};
     this[HANDLERS] = {
@@ -76,7 +74,6 @@ class Server {
     if (!connect) {
       connect = connectModule();
     }
-    connect.use(bodyParser.json());
     connect.use(middleware(this));
     this.connect = connect;
 

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -39,8 +39,6 @@ class Server {
     * @param connect: The connect app to apply the middleware to.
     * @param options:
     *           - name:     The name of the service.
-    *           - connect:  The connect app to use.
-    *                       If not specified a default Connect server is created.
     *           - basePath: The base path to prepend URL"s with.
     *           - version:  The version number of the service.
     *           - docs:     Flag indicating if generated docs should be serverd.
@@ -52,6 +50,7 @@ class Server {
     this.name = options.name || "Server Methods";
     this.version = options.version || "0.0.0";
     this.docs = _.isBoolean(options.docs) ? options.docs : true;
+    this.middleware = middleware(this);
 
     // Private state.
     this[METHODS] = {};
@@ -68,14 +67,6 @@ class Server {
       path = "";
     }
     this.basePath = `/${ path }`;
-
-    // Register middleware.
-    let connect = options.connect;
-    if (!connect) {
-      connect = connectModule();
-    }
-    connect.use(middleware(this));
-    this.connect = connect;
 
     /**
     * Registers or retrieves the complete set of methods.

--- a/test/server/manifest.test.js
+++ b/test/server/manifest.test.js
@@ -3,8 +3,6 @@ import Server from "../../src/server/server";
 import manifest from "../../src/server/manifest";
 import { getMethods } from "../../src/server/manifest";
 
-const fakeConnect = { use: () => {} };
-
 
 
 describe("Server:manifest", () => {

--- a/test/server/server-methods-stub.test.js
+++ b/test/server/server-methods-stub.test.js
@@ -2,20 +2,18 @@ import { expect } from "chai";
 import _ from "lodash";
 import Server from "../../src/server/server";
 
-const fakeConnect = { use: () => {} };
-
 
 
 describe("Server:stub-methods (executing on the server)", () => {
   let server;
   beforeEach(() => {
-    server = Server({ connect:fakeConnect });
+    server = Server({});
   });
 
 
   it("does not share methods function between instances", () => {
-    let server1 = Server({ connect:fakeConnect });
-    let server2 = Server({ connect:fakeConnect });
+    let server1 = Server({});
+    let server2 = Server({});
     expect(server1.methods).not.to.equal(server2.methods);
   });
 

--- a/test/server/server-methods.test.js
+++ b/test/server/server-methods.test.js
@@ -4,15 +4,12 @@ import ServerMethod from "../../src/server/ServerMethod";
 import Server from "../../src/server/server";
 import { METHODS } from "../../src/const";
 
-const fakeConnect = { use: () => {} };
-
-
 
 
 describe("Server:methods", () => {
   let server;
   beforeEach(() => {
-      server = Server({ connect:fakeConnect });
+      server = Server({});
   });
 
 

--- a/test/server/server.test.js
+++ b/test/server/server.test.js
@@ -1,21 +1,8 @@
 import { expect } from "chai";
 import Server from "../../src/server/server";
-const fakeConnect = { use: () => {} };
 
 
 describe("Server (instance)", () => {
-  it("has the given connect server", () => {
-    let server = Server({ connect:fakeConnect });
-    expect(server.connect).to.equal(fakeConnect);
-  });
-
-
-  it("constructs a default connect server", () => {
-    let server = Server();
-    expect(server.connect.use).to.be.an.instanceof(Function);
-  });
-
-
   it("has no base path by default", () => {
     let server = Server();
     expect(server.basePath).to.equal("/");


### PR DESCRIPTION
Conformed so `app.use` semantics for express middleware.

    var express = require("express");
    var Service = require("rest-methods/server");

    var service = Service({
      name:'My Service',
      version: '1.0.1',
      basePath: '/v1',
    });

    var app = express()
              .use(service.middleware)
              .listen(3030);
